### PR TITLE
Add quests to translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pogo-data-generator",
-  "version": "1.1.0",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pogo-data-generator",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Pokemon GO project data generator",
   "author": "TurtIeSocks",
   "license": "Apache-2.0",

--- a/src/data/base.json
+++ b/src/data/base.json
@@ -259,7 +259,10 @@
         "characterCategories": "character_category_",
         "lures": "lure_",
         "throwTypes": "throw_type_",
-        "pokemonCategories": "pokemon_categories_"
+        "pokemonCategories": "pokemon_categories_",
+        "questTypes": "quest_",
+        "questConditions": "quest_condition_",
+        "questRewardTypes": "quest_reward_"
       },
       "questVariables": {
         "prefix": "{{",
@@ -295,7 +298,8 @@
       "characters": true,
       "weather": true,
       "misc": true,
-      "pokemonCategories": true
+      "pokemonCategories": true,
+      "quests": true
     }
   }
 }

--- a/src/data/base.json
+++ b/src/data/base.json
@@ -268,7 +268,7 @@
         "prefix": "{{",
         "suffix": "}}"
       },
-      "masterfileLocale": "en",
+      "masterfileLocale": false,
       "manualTranslations": true,
       "mergeCategories": true,
       "useLanguageAsRef": false

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,8 +63,7 @@ export async function generate({ template, safe, url, test, raw }: Input = {}) {
     weather,
     translations,
   } = templateMerger(template || base)
-  const localeCheck =
-    translations.enabled && translations.options.masterfileLocale && translations.options.masterfileLocale !== 'en'
+  const localeCheck = translations.enabled && translations.options.masterfileLocale
 
   const AllPokemon = new Pokemon(pokemon.options)
   const AllItems = new Items(items.options)
@@ -168,6 +167,13 @@ export async function generate({ template, safe, url, test, raw }: Input = {}) {
           }
           if (translations.template.pokemonCategories) {
             AllTranslations.pokemonCategories(localeCode)
+          }
+          if (translations.template.quests) {
+            AllTranslations.quests(localeCode, {
+              questTypes: AllQuests.parsedQuestTypes,
+              questConditions: AllQuests.parsedConditions,
+              questRewardTypes: AllQuests.parsedRewardTypes,
+            })
           }
         }
       })

--- a/src/typings/dataTypes.ts
+++ b/src/typings/dataTypes.ts
@@ -54,9 +54,7 @@ export interface AllItems {
 }
 
 export interface AllQuests {
-  [id: string]: {
-    [id: string]: QuestSubCategory
-  }
+  [id: string]: QuestSubCategory
 }
 
 type QuestSubCategory = {

--- a/src/typings/inputs.ts
+++ b/src/typings/inputs.ts
@@ -162,6 +162,7 @@ type TranslationsTemplate = {
   weather?: boolean
   misc?: boolean
   pokemonCategories?: boolean
+  quests?: boolean
 }
 
 export interface Input {

--- a/tests/customValues.json
+++ b/tests/customValues.json
@@ -154,7 +154,7 @@
   },
   "weather": {
     "0": "Extrem",
-    "1": "Sonnig/Klar",
+    "1": "Klar",
     "2": "Regen"
   },
   "translations": {
@@ -172,14 +172,14 @@
       "pokemon%types_3": "Flug",
       "pokemon%types_4": "Gift",
       "weather_is_not_accurate_0": "Extrem",
-      "weather_is_not_accurate_1": "Sonnig/Klar",
+      "weather_is_not_accurate_1": "Klar",
       "amazing_pokemon_spawners_502": "Gletscher",
       "amazing_pokemon_spawners_503": "Moos",
       "cool_helpers_1404": "Sternenstück",
       "cool_helpers_1405": "Geschenk"
     },
     "en": {
-      "pokemon_0": "Substitute Pokemon",
+      "pokemon_0": "Substitute",
       "pokemon_1": "Bulbasaur",
       "forms_34": "Attack",
       "forms_35": "Defense",

--- a/tests/defaultValues.json
+++ b/tests/defaultValues.json
@@ -495,6 +495,32 @@
       },
       "gen_id": 6,
       "generation": "Kalos",
+      "types": [
+        "Rock",
+        "Fairy"
+      ],
+      "attack": 190,
+      "defense": 285,
+      "stamina": 137,
+      "height": 0.7,
+      "weight": 8.8,
+      "quick_moves": [
+        "Tackle",
+        "Rock Throw"
+      ],
+      "charged_moves": [
+        "Rock Slide",
+        "Moonblast",
+        "Power Gem"
+      ],
+      "family": 719,
+      "flee_rate": 0.1,
+      "capture_rate": 0.02,
+      "legendary": false,
+      "mythic": true,
+      "buddy_distance": 20,
+      "third_move_stardust": 100000,
+      "third_move_candy": 100,
       "temp_evolutions": {
         "1": {
           "attack": 342,
@@ -622,8 +648,8 @@
       "form_183": "Erlöst",
       "form_34": "Angriffsform",
       "desc_26_50": "Kräftiges Massieren seiner Backentaschen setzt einen süßen Geruch frei. Dafür nimmt man auch gerne einen leichten Elektroschock in Kauf.",
-      "grunt_5": "Rüpel (weiblich)",
-      "grunt_6": "Käfer - Rüpel (weiblich)",
+      "grunt_5": "Rüpel (Weiblich)",
+      "grunt_6": "Käfer - Rüpel (Weiblich)",
       "character_category_6": "Giovanni",
       "weather_4": "Bedeckt",
       "weather_icon_4": "☁️"
@@ -631,15 +657,15 @@
     "en": {
       "gender_1": "Male",
       "gender_2": "Female",
-      "poke_0": "Substitute Pokemon",
+      "poke_0": "Substitute",
       "poke_1": "Bulbasaur",
       "lure_503": "Mossy",
       "item_4": "Master Ball",
       "form_183": "Purified",
       "form_34": "Attack",
       "desc_26_50": "When you rub its cheeks, a sweet fragrance comes wafting out. However, you'll also get a light shock!",
-      "grunt_5": "Grunt (female)",
-      "grunt_6": "Bug - Grunt (female)",
+      "grunt_5": "Grunt (Female)",
+      "grunt_6": "Bug - Grunt (Female)",
       "character_category_6": "Giovanni",
       "weather_4": "Cloudy",
       "weather_icon_4": "☁️"


### PR DESCRIPTION
- Adds basic quest text translation support
- Adjusts some tests to account for new data
- Fixes some manual translation imports
- Fixes grunt_0 and weather_0
- Translates masterfile to En, even if it is in En already to add punctuation to certain Pokemon, if desired
