### PR TITLE
Form Separation Evos and Temp Evos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Generates templated data for Pokemon GO related projects, including:
 
 - Pokemon
 - Forms
+- Costumes
 - Moves
 - Items
 - Team Rocket Invasions
@@ -28,7 +29,6 @@ Usage:
 ```js
 // commonJS
 const { generate } = require('pogo-data-generator')
-
 // es6
 import { generate } from 'pogo-data-generator'
 
@@ -121,7 +121,7 @@ To view some static examples of what this library can create, check out these re
 
 ## Full Template
 
-This is the full template example with notes on each field. The default template if you simply call `generate()` is `src/data/base.json`
+This is the full template example with notes on each field. The default template if you simply call `generate()` is located at `src/data/base.json`
 
 ```js
 const template = {
@@ -201,6 +201,7 @@ const template = {
             questType: true,
             target: true,
             i18n: true,
+            assetsRef: true,
             translated: true,
           },
         },
@@ -295,6 +296,7 @@ const template = {
           questType: true,
           target: true,
           i18n: true,
+          assetsRef: true,
           translated: true,
         },
       },

--- a/src/classes/Masterfile.ts
+++ b/src/classes/Masterfile.ts
@@ -96,30 +96,34 @@ export default class Masterfile {
       let returnedObj: any = {}
       const ref = reference[fieldKey] ? reference[fieldKey][x] : x
 
-      Object.entries(ref).forEach(subField => {
-        let [subFieldKey, subFieldValue] = subField
-
-        if (templateChild[fieldKey] === subFieldKey) {
-          // allows for singular returns
-          returnedObj = subFieldValue
-        } else if (templateChild[fieldKey][subFieldKey]) {
-          const customKey = this.keyFormatter(subFieldKey, options)
-
-          if (typeof subFieldValue === 'object' || (reference[subFieldKey] && subFieldValue)) {
-            if (subFieldKey === 'evolutions' && (x === 776 || x === 777 || x === 778)) {
-              // Nidoran hack
-              subFieldValue = data.pokedexId === 29 ? ref.evolutions[0] : ref.evolutions[1]
-            }
-            returnedObj[customKey] = parseData(subFieldKey, subFieldValue, templateChild[fieldKey], data)
-          } else {
-            if (options.customChildObj[subFieldKey]) {
-              customChildObj(returnedObj, subFieldKey, customKey, subFieldValue)
-            } else if (subFieldValue !== undefined) {
-              returnedObj[customKey] = subFieldValue
+      try {
+        Object.entries(ref).forEach(subField => {
+          let [subFieldKey, subFieldValue] = subField
+  
+          if (templateChild[fieldKey] === subFieldKey) {
+            // allows for singular returns
+            returnedObj = subFieldValue
+          } else if (templateChild[fieldKey][subFieldKey]) {
+            const customKey = this.keyFormatter(subFieldKey, options)
+  
+            if (typeof subFieldValue === 'object' || (reference[subFieldKey] && subFieldValue)) {
+              if (subFieldKey === 'evolutions' && (x === 776 || x === 777 || x === 778)) {
+                // Nidoran hack
+                subFieldValue = data.pokedexId === 29 ? ref.evolutions[0] : ref.evolutions[1]
+              }
+              returnedObj[customKey] = parseData(subFieldKey, subFieldValue, templateChild[fieldKey], data)
+            } else {
+              if (options.customChildObj[subFieldKey]) {
+                customChildObj(returnedObj, subFieldKey, customKey, subFieldValue)
+              } else if (subFieldValue !== undefined) {
+                returnedObj[customKey] = subFieldValue
+              }
             }
           }
-        }
-      })
+        })  
+      } catch (e) {
+        console.warn(`Ref or X is undefined and it probably shouldn't be for ${reference}[${fieldKey}][${x}]`)
+      }
       return returnedObj
     }
 

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -497,10 +497,10 @@ export default class Pokemon extends Masterfile {
       this.evolutionQuests[object.templateId] = {
         questType: Rpc.QuestType[evolutionQuestTemplate.questType as QuestTypeProto],
         target: evolutionQuestTemplate.goals[0].target,
-        i18n: evolutionQuestTemplate.display.description.toLowerCase(),
+        assetsRef: evolutionQuestTemplate.display.description.toLowerCase(),
       }
       if (this.evolutionQuests[object.templateId].target) {
-        this.evolutionQuests[object.templateId].i18n = this.evolutionQuests[object.templateId].i18n.replace(
+        this.evolutionQuests[object.templateId].assetsRef = this.evolutionQuests[object.templateId].assetsRef.replace(
           'single',
           'plural'
         )
@@ -818,6 +818,8 @@ export default class Pokemon extends Masterfile {
           pokemon.forms.forEach(form => {
             this.parsedPokeForms[`${pokemon.pokedexId}_${form}`] = {
               ...pokemon,
+              evolutions: form === 0 ? pokemon.evolutions : undefined,
+              tempEvolutions: form === 0 ? pokemon.tempEvolutions : undefined,
               ...this.parsedForms[form],
               forms: [form],
             }

--- a/src/classes/Translations.ts
+++ b/src/classes/Translations.ts
@@ -277,10 +277,15 @@ export default class Translations extends Masterfile {
             this.masterfile[category] = {}
 
             Object.keys(data[category]).forEach(id => {
-              if (category == 'evolutionQuests') {
+              const questEvo = ref[data[category][id].assetsRef]
+              if (category == 'evolutionQuests' && questEvo) {
                 this.masterfile[category][id] = {
                   ...data[category][id],
-                  translated: ref[data[category][id].i18n],
+                  i18n: questEvo,
+                  translated: questEvo.toString().replace(
+                    `${this.options.questVariables.prefix}amount${this.options.questVariables.suffix}`,
+                    data[category][id].target
+                  ),
                 }
               } else if (this.options.prefix[category]) {
                 const actualId = category === 'pokemon' && formsSeparate ? data[category][id].pokedexId : id
@@ -630,8 +635,11 @@ export default class Translations extends Masterfile {
     this.parsedTranslations[locale].evolutionQuests = {}
     Object.values(evoQuests).forEach(info => {
       try {
-        const translated = this.rawTranslations[locale][info.i18n].replace('{0}', info.target.toString())
-        this.parsedTranslations[locale].evolutionQuests[info.i18n] = translated
+        const translated = this.rawTranslations[locale][info.assetsRef].replace(
+          '{0}',
+          `${this.options.questVariables.prefix}amount${this.options.questVariables.suffix}`
+        )
+        this.parsedTranslations[locale].evolutionQuests[info.assetsRef] = translated
       } catch (e) {
         console.warn(e, '\n', `Unable to translate evo quests for ${info} in ${locale}`)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,9 @@ const templateMerger = (template: { [key: string]: any }): FullTemplate => {
       })
     }
     if (category === 'translations' && template.translations) {
-      if (!template.translations.options.prefix) {
-        merged.translations.options.prefix = {}
+      merged.translations.options.questVariables = {
+        ...base.translations.options.questVariables,
+        ...template.translations.options.questVariables,
       }
       merged.translations.options.prefix = {
         ...base.translations.options.prefix,

--- a/src/typings/general.ts
+++ b/src/typings/general.ts
@@ -17,6 +17,7 @@ export interface Generation {
 export interface EvolutionQuest {
   questType?: number
   target?: number
+  assetsRef?: string
   i18n?: string
   translated?: string
 }

--- a/src/typings/inputs.ts
+++ b/src/typings/inputs.ts
@@ -85,15 +85,22 @@ interface Form extends BaseStats {
     candyCost?: boolean
     itemRequirement?: boolean
     tradeBonus?: boolean
-    questRequirement?: {
-      target?: boolean
-      i18n?: boolean
-      questType?: boolean
-    }
+    mustBeBuddy?: boolean
+    onlyDaytime?: boolean
+    onlyNighttime?: boolean
+    questRequirement?:
+      | {
+          target?: boolean
+          assetsRef?: boolean
+          i18n?: boolean
+          questType?: boolean
+          translated?: boolean
+        }
+      | string
   }
-  tempEvolutions?: TempEvolution
-  quickMoves?: Move
-  chargedMoves?: Move
+  tempEvolutions?: TempEvolution | string
+  quickMoves?: Move | string
+  chargedMoves?: Move | string
   family?: boolean
   little?: boolean
 }
@@ -101,13 +108,20 @@ interface Form extends BaseStats {
 type Move = {
   moveId?: boolean
   moveName?: boolean
-  typeId?: boolean
-  type?: boolean
+  proto?: boolean
+  type:
+    | {
+        typeId?: boolean
+        type?: boolean
+      }
+    | string
 }
 
 interface TempEvolution extends BaseStats {
   tempEvoId?: boolean
   unreleased?: boolean
+  firstEnergyCost?: boolean
+  subsequentEnergyCost?: boolean
 }
 
 type BaseStats = {
@@ -129,7 +143,7 @@ export interface TypesTempOpt {
 }
 
 type TypesTemplate = {
-  typeId: boolean
+  typeId?: boolean
   typeName?: boolean
 }
 
@@ -137,7 +151,12 @@ type MoveTemplate = {
   moveId?: boolean
   moveName?: boolean
   proto?: boolean
-  type?: boolean
+  type?:
+    | {
+        typeId?: boolean
+        typeName?: boolean
+      }
+    | string
   power?: boolean
 }
 
@@ -162,7 +181,11 @@ type InvasionTemplate = {
   gender?: boolean
   grunt?: boolean
   secondReward?: boolean
-  encounters?: boolean
+  encounters?: {
+    id: boolean
+    formId: boolean
+    position: boolean
+  }
 }
 
 type WeatherTemplate = {

--- a/tests/customValues.json
+++ b/tests/customValues.json
@@ -1,11 +1,12 @@
 {
   "pokemon": {
-    "6_%_951": {
-      "id": 6,
+    "6_%_178": {
       "name": "Glurak",
+      "id": 6,
+      "generation": "Kanto",
       "form": {
-        "formName": "Copy 2019",
-        "id": 951
+        "formName": "Normal",
+        "id": 178
       },
       "types": [
         {
@@ -35,8 +36,7 @@
       "tempEvolutions": [
         2,
         3
-      ],
-      "generation": "Kanto"
+      ]
     },
     "52_%_710": {
       "id": 52,


### PR DESCRIPTION
- Adds better logic for assigning evos and temp evos when splitting forms separately
- Adds some checks for the new evo quest logic
- Adds try/catch block in a commony place to fail
- Adds another field in the quest requirement section for better poracle translation referencing
- Fixes some missing typings
- Adjusts some test data that was no longer accurate