### PR TITLE
feat: size settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pogo-data-generator",
-  "version": "1.16.10",
+  "version": "1.17.0",
   "description": "Pokemon GO project data generator",
   "author": "TurtIeSocks",
   "license": "Apache-2.0",

--- a/src/base.ts
+++ b/src/base.ts
@@ -23,6 +23,7 @@ const baseTemplate: FullTemplate = {
         chargedMoves: false,
         questRequirement: false,
         costumeOverrideEvos: false,
+        // sizeSettings: 'name'
       },
       customFields: {
         evoId: 'pokemon',
@@ -88,6 +89,7 @@ const baseTemplate: FullTemplate = {
           costumeName: true,
         },
       },
+      // sizeSettings: 'value',
       defaultFormId: true,
       genId: true,
       generation: true,
@@ -302,27 +304,27 @@ const baseTemplate: FullTemplate = {
     options: {
       keys: {
         main: 'id',
-      }
+      },
     },
-    template: 'formatted'
+    template: 'formatted',
   },
   teams: {
     enabled: false,
     options: {
       keys: {
         main: 'id',
-      }
+      },
     },
-    template: 'formatted'
+    template: 'formatted',
   },
   routeTypes: {
     enabled: false,
     options: {
       keys: {
         main: 'id',
-      }
+      },
     },
-    template: 'formatted'
+    template: 'formatted',
   },
   translations: {
     enabled: true,

--- a/src/classes/Apk.ts
+++ b/src/classes/Apk.ts
@@ -20,6 +20,7 @@ export default class ApkReader {
       'ko-kr': 'ko',
       'ru-ru': 'ru',
       'es-es': 'es',
+      'es-mx': 'es-mx',
       'th-th': 'th',
       'tr-tr': 'tr',
     }

--- a/src/classes/Pokemon.ts
+++ b/src/classes/Pokemon.ts
@@ -621,6 +621,23 @@ export default class Pokemon extends Masterfile {
     })
   }
 
+  addExtendedStats(object: NiaMfObj) {
+    if ('pokemonExtendedSettings' in object.data) {
+      const id: number =
+        Rpc.HoloPokemonId[
+          object.data.pokemonExtendedSettings.uniqueId as PokemonIdProto
+        ]
+      if (id) {
+        if (!this.parsedPokemon[id]) {
+          this.parsedPokemon[id] = {}
+        }
+        this.parsedPokemon[id].sizeSettings = Object.entries(
+          object.data.pokemonExtendedSettings.sizeSettings,
+        ).map(([name, value]) => ({ name, value }))
+      }
+    }
+  }
+
   addFormBaseStats(
     formId: number,
     hp: number,

--- a/src/classes/Translations.ts
+++ b/src/classes/Translations.ts
@@ -49,6 +49,7 @@ export default class Translations extends Masterfile {
       de: 'German',
       en: 'English',
       es: 'Spanish',
+      'es-mx': 'LatinAmericanSpanish',
       fr: 'French',
       hi: 'Hindi',
       id: 'Indonesian',
@@ -79,6 +80,12 @@ export default class Translations extends Masterfile {
         normal: 'Normal',
         unknown: 'Desconocido',
         substitute: 'Substitución',
+      },
+      'es-mx': {
+        none: 'Ninguno',
+        normal: 'Normal',
+        unknown: 'Desconocido',
+        substitute: 'Sustituto',
       },
       fr: {
         none: 'Aucun',

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,8 @@ export async function generate({
         data[i].templateId === 'COMBAT_LEAGUE_VS_SEEKER_LITTLE_JUNGLE'
       ) {
         AllPokemon.jungleCup(data[i])
+      } else if (data[i].data.pokemonExtendedSettings) {
+        AllPokemon.addExtendedStats(data[i])
       }
     }
   }

--- a/src/typings/dataTypes.ts
+++ b/src/typings/dataTypes.ts
@@ -113,6 +113,7 @@ export interface SinglePokemon extends SingleForm {
   gymDefenderEligible?: boolean
   unreleased?: boolean
   jungle?: boolean
+  sizeSettings?: { name: string, value: number }[]
 }
 
 interface SingleForm extends BaseStats {

--- a/src/typings/general.ts
+++ b/src/typings/general.ts
@@ -27,6 +27,7 @@ export interface EvolutionQuest {
 export interface NiaMfObj {
   templateId: string
   data: {
+    templateId: string
     pokemonSettings?: {
       pokemonId: string
       modelScale: number
@@ -126,7 +127,20 @@ export interface NiaMfObj {
         title: string
       }
     }
+    pokemonExtendedSettings?: {
+      uniqueId: string
+      sizeSettings: PokemonSizeSettings
+    }
   }
+}
+
+export interface PokemonSizeSettings {
+  xxsLowerBound: number
+  xsLowerBound: number
+  mLowerBound: number
+  mUpperBound: number
+  xlUpperBound: number
+  xxlUpperBound: number
 }
 
 export interface TempEvo {

--- a/src/typings/inputs.ts
+++ b/src/typings/inputs.ts
@@ -76,6 +76,7 @@ export interface PokemonTemplate extends Form {
   gymDefenderEligible?: boolean
   unreleased?: boolean
   jungle?: boolean
+  sizeSettings?: { name: boolean, value: boolean } | string
 }
 
 interface CostumeTemplate {
@@ -348,6 +349,7 @@ export type Locales = [
   'de',
   'en',
   'es',
+  'es-mx',
   'fr',
   'hi',
   'id',

--- a/tests/rawValues.json
+++ b/tests/rawValues.json
@@ -41,6 +41,32 @@
       "transferable": true,
       "gymDefenderEligible": true,
       "genId": 1,
+      "sizeSettings": [
+        {
+          "name": "xxsLowerBound",
+          "value": 0.343
+        },
+        {
+          "name": "xsLowerBound",
+          "value": 0.35
+        },
+        {
+          "name": "mLowerBound",
+          "value": 0.525
+        },
+        {
+          "name": "mUpperBound",
+          "value": 0.875
+        },
+        {
+          "name": "xlUpperBound",
+          "value": 1.05
+        },
+        {
+          "name": "xxlUpperBound",
+          "value": 1.225
+        }
+      ],
       "evolutions": [
         {
           "evoId": 2,
@@ -83,6 +109,32 @@
       "bonusCandyCapture": 7,
       "bonusStardustCapture": 400,
       "legendary": false,
+      "sizeSettings": [
+        {
+          "name": "xxsLowerBound",
+          "value": 0.833
+        },
+        {
+          "name": "xsLowerBound",
+          "value": 0.85
+        },
+        {
+          "name": "mLowerBound",
+          "value": 1.275
+        },
+        {
+          "name": "mUpperBound",
+          "value": 2.125
+        },
+        {
+          "name": "xlUpperBound",
+          "value": 2.55
+        },
+        {
+          "name": "xxlUpperBound",
+          "value": 2.975
+        }
+      ],
       "mythic": false,
       "ultraBeast": false,
       "buddyGroupNumber": 3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,9 +758,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@na-ji/pogo-protos@<3.0.0":
-  version "2.118.0"
-  resolved "https://registry.yarnpkg.com/@na-ji/pogo-protos/-/pogo-protos-2.118.0.tgz#595dd7a439ef42576624a32bf99e1b9d42a09d2f"
-  integrity sha512-ZY3PZGBQCUGTU4H8EBSroot7t9kuFjQhwli5fjgsPct8txsBPGgdud6M+wAt7GAIiCnmmWK5suwAN8iKEuoazw==
+  version "2.127.0"
+  resolved "https://registry.yarnpkg.com/@na-ji/pogo-protos/-/pogo-protos-2.127.0.tgz#9f2c3da0568b46397e5e8ccfa167f549389c8770"
+  integrity sha512-yxKaeDdffdnPAGX0onyTvtpNjhYa44FU45wZ6ljzIaz+3mMro+obKfBTnM8RGNxJoXFiieUQuhjUjFeWpE1L1Q==
   dependencies:
     protobufjs "^6.11.3"
 
@@ -934,9 +934,9 @@
   integrity sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==
 
 "@types/node@>=13.7.0":
-  version "20.11.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.30.tgz#9c33467fc23167a347e73834f788f4b9f399d66f"
-  integrity sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==
+  version "20.12.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
+  integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
Adds size settings to Pokemon template. Usage is a bit convulated due to some *interesting* decisions I made with the templating function. See added, commented out text in the `src/base.ts` file if you want to accomplish the same format as what comes in from the GM.

Closes #100 