### PR TITLE
fix: error logs

### DIFF
--- a/src/classes/Translations.ts
+++ b/src/classes/Translations.ts
@@ -979,7 +979,11 @@ export default class Translations extends Masterfile {
     this.parsedTranslations[locale].evolutionQuests = {}
     Object.values(evoQuests).forEach((info) => {
       try {
-        const translated = this.rawTranslations[locale][info.assetsRef].replace(
+        const rawValue = this.rawTranslations[locale][info.assetsRef];
+        if (!rawValue) {
+          throw new Error(`Missing translation for assetsRef: ${info.assetsRef}`);
+        }
+        const translated = rawValue.replace(
           '{0}',
           `${this.options.questVariables.prefix}amount${this.options.questVariables.suffix}`,
         )
@@ -989,7 +993,7 @@ export default class Translations extends Masterfile {
         console.warn(
           e,
           '\n',
-          `Unable to translate evo quests for ${info} in ${locale}`,
+          `Unable to translate evo quests for ${JSON.stringify(info)} in ${locale}`,
         )
       }
     })


### PR DESCRIPTION
error was happening quite often in pogo-translations. This should help to find the reason easier:

```
TypeError: Cannot read properties of undefined (reading 'replace')
    at /home/runner/work/pogo-translations/pogo-translations/node_modules/pogo-data-generator/dist/classes/Translations.js:730:81
    at Array.forEach (<anonymous>)
    at Translations.parseEvoQuests (/home/runner/work/pogo-translations/pogo-translations/node_modules/pogo-data-generator/dist/classes/Translations.js:728:34)
    at /home/runner/work/pogo-translations/pogo-translations/node_modules/pogo-data-generator/dist/index.js:170:37
```