### PR TITLE
fix: mega z evo_5

### DIFF
--- a/src/classes/Translations.ts
+++ b/src/classes/Translations.ts
@@ -936,14 +936,14 @@ export default class Translations extends Masterfile {
         !Object.prototype.hasOwnProperty.call(
           Rpc.HoloTemporaryEvolutionId,
           'TEMP_EVOLUTION_MEGA_Z',
-        ) &&
-        !this.parsedTranslations[locale].misc[
-          `${this.options.prefix.evolutions}5`
-        ]
+        )
       ) {
-        this.parsedTranslations[locale].misc[
-          `${this.options.prefix.evolutions}5`
-        ] = this.capitalize('MEGA_Z')
+        const evo5Key = `${this.options.prefix.evolutions}5`
+        if (!this.parsedTranslations[locale].misc[evo5Key]) {
+          this.parsedTranslations[locale].misc[evo5Key] = this.capitalize(
+            'MEGA_Z',
+          )
+        }
       }
       Object.entries(Rpc.PokemonDisplayProto.Alignment).forEach((proto) => {
         const [name, id] = proto


### PR DESCRIPTION
approach to fix translation key `evo_5` missing.

In case of missing `TEMP_EVOLUTION_MEGA_Z` we always want to add `evo_5` to translations