### PR TITLE
feat: overlay Niantic patch translations on top of APK data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pogo-data-generator",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Pokemon GO project data generator",
   "author": "TurtIeSocks",
   "license": "Apache-2.0",

--- a/src/classes/Translations.ts
+++ b/src/classes/Translations.ts
@@ -14,9 +14,16 @@ import type { TypeProto } from '../typings/protos'
 import Masterfile from './Masterfile'
 
 export default class Translations extends Masterfile {
+  static readonly DEFAULT_APK_URL =
+    'https://raw.githubusercontent.com/sora10pls/holoholo-text/refs/heads/main/Release/English/en-us_raw.json'
+
+  static readonly DEFAULT_REMOTE_URL =
+    'https://raw.githubusercontent.com/sora10pls/holoholo-text/refs/heads/main/Remote/English/en-us_formatted.txt'
+
   options: Options
   translationApkUrl: string
   translationRemoteUrl: string
+  translationPatchUrl: string
   rawTranslations: TranslationKeys
   manualTranslations: { [key: string]: TranslationKeys }
   parsedTranslations: { [key: string]: TranslationKeys }
@@ -29,8 +36,9 @@ export default class Translations extends Masterfile {
 
   constructor(
     options: Options,
-    translationApkUrl = 'https://raw.githubusercontent.com/sora10pls/holoholo-text/refs/heads/main/Release/English/en-us_raw.json',
-    translationRemoteUrl = 'https://raw.githubusercontent.com/sora10pls/holoholo-text/refs/heads/main/Remote/English/en-us_formatted.txt',
+    translationApkUrl = Translations.DEFAULT_APK_URL,
+    translationRemoteUrl = Translations.DEFAULT_REMOTE_URL,
+    translationPatchUrl = 'https://asset-cdn-rel.nianticstatic.com/i18n/patch_i18n_en-us.json.gz',
   ) {
     super()
     this.collator = new Intl.Collator(undefined, {
@@ -40,6 +48,7 @@ export default class Translations extends Masterfile {
     this.options = options
     this.translationApkUrl = translationApkUrl
     this.translationRemoteUrl = translationRemoteUrl
+    this.translationPatchUrl = translationPatchUrl
 
     this.rawTranslations = {}
     this.manualTranslations = {}
@@ -164,6 +173,55 @@ export default class Translations extends Masterfile {
     return str.replace(/\r/g, '').replace(/\n/g, '').replace(/"/g, '”')
   }
 
+  async fetchGzipJson(url: string): Promise<any> {
+    const response = await fetch(url)
+    if (!response.ok || !response.body) {
+      throw new Error(`${response.status} ${response.statusText} URL: ${url}`)
+    }
+    const decompressed = response.body.pipeThrough(
+      new DecompressionStream('gzip'),
+    )
+    return JSON.parse(await new Response(decompressed).text())
+  }
+
+  // Only the final path segment carries the locale, so a mirror hosted under an
+  // en-us directory keeps that directory while its filename is localized. Works
+  // for Niantic's patch_i18n_en-us.json.gz and for a bare en-us.json.gz alike.
+  // The query and fragment are held back: they can contain slashes of their own,
+  // and a locale sitting in a query parameter isn't ours to rewrite.
+  static localizePatchUrl(url: string, localeCode: string) {
+    const [, path, suffix = ''] = url.match(/^([^?#]*)([?#].*)?$/) || []
+    if (path === undefined) return url
+    return (
+      path.replace(/[^/]*$/, (segment) =>
+        segment.split('en-us').join(localeCode),
+      ) + suffix
+    )
+  }
+
+  // Niantic's live patch feed carries hotfix strings pushed between APK
+  // releases. It never throws: a missing patch just leaves the base data as is.
+  async applyPatchTranslations(
+    locale: Locales[number],
+    localeCode: string,
+  ): Promise<void> {
+    if (!this.translationPatchUrl) return
+    try {
+      const patch = await this.fetchGzipJson(
+        Translations.localizePatchUrl(this.translationPatchUrl, localeCode),
+      )
+      const patchData: string[] = patch?.data || []
+
+      for (let i = 0; i + 1 < patchData.length; i += 2) {
+        this.rawTranslations[locale][patchData[i]] = this.removeEscapes(
+          patchData[i + 1],
+        )
+      }
+    } catch (e) {
+      console.warn(e, '\n', `Unable to fetch translation patch for ${locale}`)
+    }
+  }
+
   async fetchTranslations(
     locale: Locales[number],
     availableManualTranslations: string[],
@@ -193,6 +251,12 @@ export default class Translations extends Masterfile {
       characterCategories: {},
       misc: {},
     }
+    const localeInfo = this.codes[locale] || {
+      name: 'English',
+      code: 'en-us',
+    }
+    const isCustomRemoteUrl =
+      this.translationRemoteUrl !== Translations.DEFAULT_REMOTE_URL
     try {
       if (!this.codes[locale]) {
         console.warn(`Game assets unavailable for ${locale}, using English`)
@@ -201,30 +265,53 @@ export default class Translations extends Masterfile {
         this.generics[locale] = this.generics.en
         console.warn(`Generics unavailable for ${locale}, using English`)
       }
-      const localeInfo = this.codes[locale] || {
-        name: 'English',
-        code: 'en-us',
-      }
-      const { data }: { data: string[] } = (await this.fetch(
-        this.translationApkUrl.replace(
-          'English/en-us',
-          `${localeInfo.name}/${localeInfo.code}`,
-        ),
-      )) || { data: [] }
+      // Real APK text (Translations.fromApk) already covers the full set for
+      // every locale, so the built-in default URL is only needed as a
+      // fallback if that failed. A caller-supplied URL is always fetched,
+      // since it may carry strings the APK doesn't have.
+      const isCustomApkUrl =
+        this.translationApkUrl !== Translations.DEFAULT_APK_URL
+      if (
+        isCustomApkUrl ||
+        Object.keys(this.rawTranslations[locale]).length === 0
+      ) {
+        const { data }: { data: string[] } = (await this.fetch(
+          this.translationApkUrl.replace(
+            'English/en-us',
+            `${localeInfo.name}/${localeInfo.code}`,
+          ),
+        )) || { data: [] }
 
-      for (let i = 0; i < data.length; i += 2) {
-        this.rawTranslations[locale][data[i]] = this.removeEscapes(data[i + 1])
+        for (let i = 0; i < data.length; i += 2) {
+          this.rawTranslations[locale][data[i]] = this.removeEscapes(
+            data[i + 1],
+          )
+        }
       }
-
-      const textFile = ['hi', 'id'].includes(locale)
-        ? ''
-        : (await this.fetch(
-            this.translationRemoteUrl.replace(
-              'English/en-us',
-              `${localeInfo.name}/${localeInfo.code}`,
-            ),
-            true,
-          )) || ''
+    } catch (e) {
+      console.warn(e, '\n', `Unable to process ${locale} APK translations`)
+    }
+    // A caller-supplied remote feed is authoritative, so the built-in patch goes
+    // underneath it. With the default feed the patch goes on top: both carry the
+    // same keys, but the formatted text file truncates any value that spans
+    // multiple lines, which the patch preserves. Either way the patch sits
+    // between the two source attempts, so neither one failing can drop it.
+    if (isCustomRemoteUrl) {
+      await this.applyPatchTranslations(locale, localeInfo.code)
+    }
+    try {
+      // The built-in feed had no Hindi or Indonesian when they were added, but a
+      // caller-supplied one may well carry them.
+      const textFile =
+        !isCustomRemoteUrl && ['hi', 'id'].includes(locale)
+          ? ''
+          : (await this.fetch(
+              this.translationRemoteUrl.replace(
+                'English/en-us',
+                `${localeInfo.name}/${localeInfo.code}`,
+              ),
+              true,
+            )) || ''
       const splitText = textFile.split('\n')
 
       splitText.forEach((line: string, i: number) => {
@@ -238,6 +325,9 @@ export default class Translations extends Masterfile {
       })
     } catch (e) {
       console.warn(e, '\n', `Unable to process ${locale} from GM`)
+    }
+    if (!isCustomRemoteUrl) {
+      await this.applyPatchTranslations(locale, localeInfo.code)
     }
     try {
       if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export async function generate({
   url,
   translationApkUrl,
   translationRemoteUrl,
+  translationPatchUrl,
   raw,
   pokeApi,
   apkCache,
@@ -98,6 +99,7 @@ export async function generate({
     translations.options,
     translationApkUrl,
     translationRemoteUrl,
+    translationPatchUrl,
   )
   const AllPokeApi = new PokeApi(pokeApiBaseUrl)
   const AllMisc = new Misc()

--- a/src/typings/inputs.ts
+++ b/src/typings/inputs.ts
@@ -381,6 +381,7 @@ export interface Input {
   url?: string
   translationApkUrl?: string
   translationRemoteUrl?: string
+  translationPatchUrl?: string
   template?: FullTemplate
   test?: boolean
   raw?: boolean

--- a/tests/translations.patch.test.js
+++ b/tests/translations.patch.test.js
@@ -1,0 +1,293 @@
+const zlib = require('node:zlib')
+
+const Translations = require('../dist/classes/Translations').default
+const base = require('../dist/base').default
+
+const gzipJsonResponse = (payload) => {
+  const gzipped = zlib.gzipSync(Buffer.from(JSON.stringify(payload)))
+  return { ok: true, body: new Response(gzipped).body }
+}
+
+const remoteTextResponse = (pairs) => ({
+  ok: true,
+  text: async () =>
+    Object.entries(pairs)
+      .map(([key, value]) => `RESOURCE ID: ${key}\nTEXT: ${value}`)
+      .join('\n'),
+})
+
+const makeTranslations = ({
+  translationApkUrl,
+  translationPatchUrl,
+  translationRemoteUrl,
+} = {}) => {
+  const options = JSON.parse(JSON.stringify(base.translations.options))
+  return new Translations(
+    options,
+    translationApkUrl,
+    translationRemoteUrl,
+    translationPatchUrl,
+  )
+}
+
+describe('Translations patch overlay', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  test('merges patch data over existing APK translations, overriding changed keys and adding new ones', async () => {
+    const translations = makeTranslations()
+    translations.rawTranslations.hi = { foo: 'base foo', bar: 'base bar' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_hi-in.json.gz')) {
+        return gzipJsonResponse({
+          data: ['bar', 'patched bar', 'baz', 'brand new baz'],
+        })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.foo).toBe('base foo')
+    expect(translations.rawTranslations.hi.bar).toBe('patched bar')
+    expect(translations.rawTranslations.hi.baz).toBe('brand new baz')
+    // the default APK endpoint must not be hit when APK data is already loaded
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to the built-in JSON endpoint when APK data for the locale is missing', async () => {
+    const translations = makeTranslations()
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_hi-in.json.gz')) {
+        return gzipJsonResponse({ data: [] })
+      }
+      if (url.includes('Release/Hindi/hi-in_raw.json')) {
+        return { ok: true, json: async () => ({ data: ['greeting', 'hello'] }) }
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.greeting).toBe('hello')
+  })
+
+  test('leaves base translations intact when the patch fetch fails', async () => {
+    const translations = makeTranslations()
+    translations.rawTranslations.hi = { foo: 'base foo', bar: 'base bar' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_hi-in.json.gz')) {
+        return { ok: false, status: 500, statusText: 'Server Error' }
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi).toEqual({
+      foo: 'base foo',
+      bar: 'base bar',
+    })
+  })
+
+  test('always fetches an explicitly configured custom APK URL even when APK data is already present', async () => {
+    const customUrl = 'https://example.com/custom-mirror/English/en-us_raw.json'
+    const translations = makeTranslations({ translationApkUrl: customUrl })
+    translations.rawTranslations.hi = { foo: 'base foo' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_hi-in.json.gz')) {
+        return gzipJsonResponse({ data: [] })
+      }
+      if (url === 'https://example.com/custom-mirror/Hindi/hi-in_raw.json') {
+        return {
+          ok: true,
+          json: async () => ({ data: ['custom_key', 'custom value'] }),
+        }
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.custom_key).toBe('custom value')
+  })
+
+  test('applies the patch on top of the default remote feed, which truncates multi line values', async () => {
+    const translations = makeTranslations()
+    translations.rawTranslations.de = { shared: 'base' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_de-de.json.gz')) {
+        return gzipJsonResponse({ data: ['shared', 'full value'] })
+      }
+      if (url.includes('Remote/German/de-de_formatted.txt')) {
+        return remoteTextResponse({ shared: 'truncated value' })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('de', [])
+
+    expect(translations.rawTranslations.de.shared).toBe('full value')
+  })
+
+  test('keeps a caller configured remote feed authoritative over the patch', async () => {
+    const translations = makeTranslations({
+      translationRemoteUrl: 'https://example.com/custom/English/en-us_raw.txt',
+    })
+    translations.rawTranslations.de = { shared: 'base' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_de-de.json.gz')) {
+        return gzipJsonResponse({
+          data: ['shared', 'patch value', 'onlyInPatch', 'patch only'],
+        })
+      }
+      if (url === 'https://example.com/custom/German/de-de_raw.txt') {
+        return remoteTextResponse({ shared: 'custom value' })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('de', [])
+
+    expect(translations.rawTranslations.de.shared).toBe('custom value')
+    // keys the custom feed doesn't define still come from the patch
+    expect(translations.rawTranslations.de.onlyInPatch).toBe('patch only')
+  })
+
+  test('localizes a custom patch URL that does not keep the Niantic basename', async () => {
+    const translations = makeTranslations({
+      translationPatchUrl: 'https://mirror.example/i18n/en-us.json.gz',
+    })
+    translations.rawTranslations.hi = { foo: 'base foo' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url === 'https://mirror.example/i18n/hi-in.json.gz') {
+        return gzipJsonResponse({ data: ['foo', 'hindi foo'] })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.foo).toBe('hindi foo')
+  })
+
+  test('localizes only the final path segment of a custom patch URL', async () => {
+    const translations = makeTranslations({
+      translationPatchUrl:
+        'https://cdn.example.com/en-us/i18n/patch_i18n_en-us.json.gz',
+    })
+    translations.rawTranslations.hi = { foo: 'base foo' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (
+        url === 'https://cdn.example.com/en-us/i18n/patch_i18n_hi-in.json.gz'
+      ) {
+        return gzipJsonResponse({ data: ['foo', 'hindi foo'] })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.foo).toBe('hindi foo')
+  })
+
+  test('localizes the path only, leaving the query and fragment untouched', async () => {
+    const translations = makeTranslations({
+      translationPatchUrl:
+        'https://mirror.example/i18n/en-us.json.gz?redirect=/cache&v=en-us#en-us',
+    })
+    translations.rawTranslations.hi = { foo: 'base foo' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (
+        url ===
+        'https://mirror.example/i18n/hi-in.json.gz?redirect=/cache&v=en-us#en-us'
+      ) {
+        return gzipJsonResponse({ data: ['foo', 'hindi foo'] })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.foo).toBe('hindi foo')
+  })
+
+  test('fetches a custom remote feed for hi and id, where the built-in one is skipped', async () => {
+    const translations = makeTranslations({
+      translationRemoteUrl: 'https://example.com/custom/English/en-us_raw.txt',
+    })
+    translations.rawTranslations.hi = { shared: 'base' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_hi-in.json.gz')) {
+        return gzipJsonResponse({
+          data: ['shared', 'patch value', 'onlyInPatch', 'patch only'],
+        })
+      }
+      if (url === 'https://example.com/custom/Hindi/hi-in_raw.txt') {
+        return remoteTextResponse({ shared: 'custom value' })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.shared).toBe('custom value')
+    expect(translations.rawTranslations.hi.onlyInPatch).toBe('patch only')
+  })
+
+  test('still applies the patch and the remote feed when the APK fetch fails', async () => {
+    const translations = makeTranslations({
+      translationRemoteUrl: 'https://example.com/custom/English/en-us_raw.txt',
+    })
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('Release/German/de-de_raw.json')) {
+        return { ok: false, status: 500, statusText: 'Server Error' }
+      }
+      if (url.includes('patch_i18n_de-de.json.gz')) {
+        return gzipJsonResponse({ data: ['fromPatch', 'patch value'] })
+      }
+      if (url === 'https://example.com/custom/German/de-de_raw.txt') {
+        return remoteTextResponse({ fromRemote: 'remote value' })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('de', [])
+
+    expect(translations.rawTranslations.de.fromPatch).toBe('patch value')
+    expect(translations.rawTranslations.de.fromRemote).toBe('remote value')
+  })
+
+  test('skips the patch fetch entirely when the patch URL is empty', async () => {
+    const translations = makeTranslations({ translationPatchUrl: '' })
+    translations.rawTranslations.hi = { foo: 'base foo' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(translations.rawTranslations.hi).toEqual({ foo: 'base foo' })
+  })
+})


### PR DESCRIPTION
Fetching the patch file directly is more accurate than waiting for a github repo update.

The real APK download (fromApk) already provides the full translation set for every locale, so the sora10pls JSON fetch in fetchTranslations is now fallback-only, used only if that data is missing.

Additionally, merge Niantic's live patch_i18n_{locale}.json.gz feed on top of the base data. It carries hotfix-level string updates/additions pushed between APK releases, which the base data lags behind on.

Tested locally and compared output, like this we get about 400 additional translations