### PR TITLE
fix: resolve <<key>> references in translation values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pogo-data-generator",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Pokemon GO project data generator",
   "author": "TurtIeSocks",
   "license": "Apache-2.0",

--- a/src/classes/Translations.ts
+++ b/src/classes/Translations.ts
@@ -222,6 +222,39 @@ export default class Translations extends Masterfile {
     }
   }
 
+  // Niantic expresses a handful of strings as a reference to another key, e.g.
+  // move_name_0502 is "<<move_name_0311>>+". Nothing downstream understands that
+  // syntax, so the markers are substituted once every source has been merged.
+  // A value is only rewritten when all of its markers resolve: one pointing at a
+  // missing key, or looping back on itself, leaves the whole value untouched so
+  // the raw marker stays visible instead of a half-built string.
+  resolveReferences(locale: Locales[number]) {
+    const raw = this.rawTranslations[locale]
+
+    const resolve = (value: string, seen: Set<string>): string | undefined => {
+      let unresolved = false
+      const resolved = value.replace(/<<(\w+)>>/g, (_marker, key: string) => {
+        const target = seen.has(key) ? undefined : raw[key]
+        const nested =
+          target === undefined
+            ? undefined
+            : resolve(target, new Set(seen).add(key))
+        if (nested === undefined) {
+          unresolved = true
+          return ''
+        }
+        return nested
+      })
+      return unresolved ? undefined : resolved
+    }
+
+    Object.entries(raw).forEach(([key, value]) => {
+      if (value.includes('<<')) {
+        raw[key] = resolve(value, new Set([key])) ?? value
+      }
+    })
+  }
+
   async fetchTranslations(
     locale: Locales[number],
     availableManualTranslations: string[],
@@ -440,6 +473,7 @@ export default class Translations extends Masterfile {
     } catch (e) {
       console.warn(e, '\n', `Unable to fetch manual translations for ${locale}`)
     }
+    this.resolveReferences(locale)
   }
 
   mergeManualTranslations(locale: string) {

--- a/tests/translations.patch.test.js
+++ b/tests/translations.patch.test.js
@@ -291,3 +291,78 @@ describe('Translations patch overlay', () => {
     expect(translations.rawTranslations.hi).toEqual({ foo: 'base foo' })
   })
 })
+
+describe('Reference resolution', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  const resolved = (raw) => {
+    const translations = makeTranslations({ translationPatchUrl: '' })
+    translations.rawTranslations.hi = raw
+    translations.resolveReferences('hi')
+    return translations.rawTranslations.hi
+  }
+
+  test('substitutes a reference marker with the value it points at', () => {
+    expect(
+      resolved({
+        move_name_0311: 'फ़ेल स्टिंगर',
+        move_name_0502: '<<move_name_0311>>+',
+      }).move_name_0502,
+    ).toBe('फ़ेल स्टिंगर+')
+  })
+
+  test('resolves a reference whose target is itself a reference', () => {
+    expect(resolved({ a: 'base', b: '<<a>>+', c: '<<b>>+' }).c).toBe('base++')
+  })
+
+  test('leaves a marker alone when its target is missing', () => {
+    expect(
+      resolved({ move_name_0502: '<<move_name_0311>>+' }).move_name_0502,
+    ).toBe('<<move_name_0311>>+')
+  })
+
+  test('does not loop forever on a cyclic reference', () => {
+    const out = resolved({ a: '<<b>>', b: '<<a>>' })
+    expect(out.a).toBe('<<b>>')
+    expect(out.b).toBe('<<a>>')
+  })
+
+  test('ignores markup that is not a reference', () => {
+    const out = resolved({
+      truncated: 'ends with markup<<b>',
+      anchor: 'see <a href=”x”>>site</a>',
+    })
+    expect(out.truncated).toBe('ends with markup<<b>')
+    expect(out.anchor).toBe('see <a href=”x”>>site</a>')
+  })
+
+  test('runs as part of fetchTranslations, after every source is merged', async () => {
+    const translations = makeTranslations()
+    translations.rawTranslations.hi = { move_name_0311: 'base name' }
+
+    global.fetch = jest.fn().mockImplementation(async (url) => {
+      if (url.includes('patch_i18n_hi-in.json.gz')) {
+        return gzipJsonResponse({
+          data: ['move_name_0502', '<<move_name_0311>>+'],
+        })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await translations.fetchTranslations('hi', [])
+
+    expect(translations.rawTranslations.hi.move_name_0502).toBe('base name+')
+  })
+})


### PR DESCRIPTION
Niantic expresses a few strings as a reference to another key — `move_name_0502`
is literally `"<<move_name_0311>>+"`. Nothing downstream understood that syntax,
so 26 `move_name_*` keys leaked the raw marker into the output.

`resolveReferences` substitutes them once every source (APK → JSON fallback →
remote → patch) has merged, recursively and with a cycle guard. A value is only
rewritten when all of its markers resolve, so an unresolvable one stays visible
instead of producing a half-built string. Markup that only looks like a marker —
a truncated `<<b>` in a German event description, an `href=”…”>>` in an
Indonesian link — is left alone.

The remote text feed has carried these markers for every locale for a while, so
`en`/`de`/`ja` were already affected; `hi` and `id` were shielded only because
that feed is skipped for them, and the patch overlay in v2.3.0 exposed them
there too. Visible downstream in
[pogo-translations@ee43a1a8](https://github.com/WatWowMap/pogo-translations/commit/ee43a1a8),
where `moves_hi.json` regressed to `"<<move_name_0311>>+"`.

Verified live across `en`/`de`/`hi`/`id`/`ja`: 26 unresolved → 0.