### PR TITLE
ci: give yarn an empty NODE_AUTH_TOKEN on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,12 @@ jobs:
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: npm install -g npm@latest
+      # setup-node's registry-url writes an .npmrc referencing ${NODE_AUTH_TOKEN}.
+      # Publishing is done via OIDC, so no such token exists, and yarn v1 aborts
+      # on an env var it cannot expand. npm itself treats the empty value as no
+      # auth and falls through to trusted publishing.
       - run: yarn
+        env:
+          NODE_AUTH_TOKEN: ''
       - run: ./node_modules/.bin/tsc
       - run: npm publish


### PR DESCRIPTION
setup-node's registry-url writes an .npmrc containing ${NODE_AUTH_TOKEN}. Publishing goes through OIDC trusted publishing, so no such token exists, and yarn v1 aborts rather than expanding an env var that is absent: "Failed to replace env in config".

Defining it as empty is enough for yarn's expansion to succeed. npm reads the same empty value as no auth and falls through to trusted publishing, which is what already happens today.